### PR TITLE
Fix req.txt, changed .py files to fit convention

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,19 +3,20 @@ from keyauth import api
 import os
 import os.path
 
+KEYSAVE_PATH = "C:\\ProgramData\\keysave.txt"
+
 keyauthapp = api("your app name here", "your ownerid here", "your app secret here")
 
 print("Initializing")
 keyauthapp.init()
 
-if os.path.exists('C:\\ProgramData\\keysave.txt'):
-    with open ("C:\\ProgramData\\keysave.txt", "r") as file:
-    data=file.readlines()
+if os.path.exists(KEYSAVE_PATH):
+    with open (KEYSAVE_PATH, "r") as file:
+        data = file.readlines()
     keyauthapp.login(data)
 else:
-    _key = input('Enter your key: ')
-    keyauthapp.login(_key)
-
-keysave = open("C:\\ProgramData\\keysave.txt", "w")
-n = keysave.write(_key)
-keysave.close()
+    key = input('Enter your key: ')
+    keyauthapp.login(key)
+    keysave = open(KEYSAVE_PATH, "w")
+    n = keysave.write(key)
+    keysave.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests,
-requests_toolbelt,
-pycryptodome,
+requests
+requests_toolbelt
+pycryptodome


### PR DESCRIPTION
I moved the hardcoded and repeated keypath to a variable, I changed some variable names to fit with convention (starting with _ if the var is unused) and I fixed the requirements.txt, the lines shouldn't have commas on the end.
I'm also curious as to why you are ignoring ssl certificates when making a request to your server, it makes it a lot easier for someone to just edit their etc/hosts file and always respond with "KeyAuth_Valid".
Edit: Also please ignore my typo in the commit name