### PR TITLE
Fixing the example so it actually works

### DIFF
--- a/keyauth.py
+++ b/keyauth.py
@@ -85,17 +85,17 @@ class api:
 
         if response == "KeyAuth_Valid":
             print("Logged in")
-        if response == "KeyAuth_Invalid":
+        elif response == "KeyAuth_Invalid":
             print("Key not found")
             if os.path.exists(KEYSAVE_PATH):
                 os.remove(KEYSAVE_PATH)
                 sys.exit()
-        if response == "KeyAuth_InvalidHWID":
+        elif response == "KeyAuth_InvalidHWID":
             print("This computer doesn't match the computer the key is locked to. If you reset your computer, contact the application owner")
             if os.path.exists(KEYSAVE_PATH):
                 os.remove(KEYSAVE_PATH)
                 sys.exit()
-        if response == "KeyAuth_Expired":
+        elif response == "KeyAuth_Expired":
             print("This key is expired")
             if os.path.exists(KEYSAVE_PATH):
                 os.remove(KEYSAVE_PATH)

--- a/main.py
+++ b/main.py
@@ -3,19 +3,20 @@ from keyauth import api
 import os
 import os.path
 
+KEYSAVE_PATH = "C:\\ProgramData\\keysave.txt"
+
 keyauthapp = api("your app name here", "your ownerid here", "your app secret here")
 
 print("Initializing")
 keyauthapp.init()
 
-if os.path.exists('C:\\ProgramData\\keysave.txt'):
-    with open ("C:\\ProgramData\\keysave.txt", "r") as file:
-    data=file.readlines()
+if os.path.exists(KEYSAVE_PATH):
+    with open (KEYSAVE_PATH, "r") as file:
+        data = file.readlines()
     keyauthapp.login(data)
 else:
-    _key = input('Enter your key: ')
-    keyauthapp.login(_key)
-
-keysave = open("C:\\ProgramData\\keysave.txt", "w")
-n = keysave.write(_key)
-keysave.close()
+    key = input('Enter your key: ')
+    keyauthapp.login(key)
+    keysave = open(KEYSAVE_PATH, "w")
+    n = keysave.write(key)
+    keysave.close()

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ keyauthapp.init()
 
 if os.path.exists(KEYSAVE_PATH):
     with open (KEYSAVE_PATH, "r") as file:
-        data = file.readlines()
+        data = file.readline()
     keyauthapp.login(data)
 else:
     key = input('Enter your key: ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests,
-requests_toolbelt,
-pycryptodome,
+requests
+requests_toolbelt
+pycryptodome


### PR DESCRIPTION
I moved the hardcoded and repeated keypath to a variable, I changed some variable names to fit with convention (starting with _ if the var is unused) and I fixed the requirements.txt, the lines shouldn't have commas on the end.
I'm also curious as to why you are ignoring ssl certificates when making a request to your server, it makes it a lot easier for someone to just edit their etc/hosts file and always respond with "KeyAuth_Valid".
This is a second pull request, I decided to actually test the program and came across more things that didn't work.