### PR TITLE
Fix HWID Fetch on Linux

### DIFF
--- a/keyauth.py
+++ b/keyauth.py
@@ -457,10 +457,9 @@ class others:
     @staticmethod
     def get_hwid():
         if platform.system() != "Windows":
-            f = open("/etc/machine-id")
-            hwid = f.read()
-            f.close()
-            return hwid
+            with open("/etc/machine-id") as f:
+                hwid = f.read()
+                return hwid
 
         cmd = subprocess.Popen(
             "wmic useraccount where name='%username%' get sid", stdout=subprocess.PIPE, shell=True)

--- a/keyauth.py
+++ b/keyauth.py
@@ -457,7 +457,10 @@ class others:
     @staticmethod
     def get_hwid():
         if platform.system() != "Windows":
-            return subprocess.Popen('hal-get-property --udi /org/freedesktop/Hal/devices/computer --key system.hardware.uuid'.split())
+            f = open("/etc/machine-id")
+            hwid = f.read()
+            f.close()
+            return hwid
 
         cmd = subprocess.Popen(
             "wmic useraccount where name='%username%' get sid", stdout=subprocess.PIPE, shell=True)


### PR DESCRIPTION
`hal-get-propterty` is apart of the HAL package which has been deprecated and broken since 2011. It instead reads the machine ID from `/etc/machine-id`. I would fetch it from `/sys/class/dmi/id/product_uuid` but that requires root privileges. 